### PR TITLE
install cloudformation guard to aws-cdk-go container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,9 @@ RUN mkdir -p /tmp && \
     ./tmp/aws/install && \
     rm -rf /tmp/aws
 
+## Install Cloudformation Guard 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
+
 # Install eXeCute
 RUN go install github.com/joerdav/xc/cmd/xc@72f8c2aa4fb993b436c9297590f613ed2f24513f
 


### PR DESCRIPTION
Install cloudformation guard on to container to run cfn-guard commands 